### PR TITLE
Move cockpit guidance into config

### DIFF
--- a/docs/tooling/workspace-cli.md
+++ b/docs/tooling/workspace-cli.md
@@ -91,6 +91,8 @@ Purpose
 - Copy the shared manual multi-repo cockpit-root starter into a target
   directory.
 - Write `workspace-cockpit.toml` as the source of truth for that root.
+- Keep the repo map and section-level cockpit guidance in that config instead
+  of hand-maintaining root markdown files.
 - Generate `AGENTS.md`, `docs/README.md`, and `docs/session-prompt.md` from
   that config.
 - Keep non-repo workspace roots thin, link-heavy, and synced from
@@ -103,6 +105,8 @@ Purpose
 - Regenerate a manual multi-repo cockpit root from `workspace-cockpit.toml`.
 - Keep root entrypoint docs manifest-driven even when the cockpit is not a
   tenant `workspace sync` surface.
+- Re-render both repo listings and section-level guidance bullets from the
+  tracked cockpit config.
 
 ## `workspace status-cockpit-root`
 

--- a/odoo_devkit/workspace_cockpit.py
+++ b/odoo_devkit/workspace_cockpit.py
@@ -19,6 +19,13 @@ class WorkspaceCockpitManifest:
     schema_version: int
     manifest_path: Path
     repos: tuple[WorkspaceCockpitRepoDefinition, ...]
+    agents_first_read_lines: tuple[str, ...]
+    agents_ownership_lines: tuple[str, ...]
+    agents_notes_lines: tuple[str, ...]
+    docs_external_reference_lines: tuple[str, ...]
+    docs_working_split_lines: tuple[str, ...]
+    docs_operational_note_lines: tuple[str, ...]
+    session_prompt_rule_lines: tuple[str, ...]
     plans_directory: str = "~/.codex/plans"
 
     @property
@@ -63,10 +70,27 @@ def load_workspace_cockpit_manifest(manifest_path: Path) -> WorkspaceCockpitMani
 
     repos = tuple(_parse_repo_definition(entry) for entry in repos_value)
     _validate_repo_definitions(repos)
+    guidance_table = _read_optional_table(manifest_data, "guidance")
+    agents_table = _read_optional_table(guidance_table, "agents")
+    docs_table = _read_optional_table(guidance_table, "docs")
+    session_prompt_table = _read_optional_table(guidance_table, "session_prompt")
     return WorkspaceCockpitManifest(
         schema_version=schema_version,
         manifest_path=manifest_path.resolve(),
         repos=repos,
+        agents_first_read_lines=_read_string_tuple(agents_table, "first_reads") or _default_agents_first_read_lines(),
+        agents_ownership_lines=_read_string_tuple(agents_table, "ownership") or _default_agents_ownership_lines(),
+        agents_notes_lines=_read_string_tuple(agents_table, "notes") or _default_agents_note_lines(),
+        docs_external_reference_lines=(
+            _read_string_tuple(docs_table, "external_reference_boundary") or _default_docs_external_reference_lines()
+        ),
+        docs_working_split_lines=_read_string_tuple(docs_table, "working_split") or _default_docs_working_split_lines(),
+        docs_operational_note_lines=(
+            _read_string_tuple(docs_table, "operational_notes") or _default_docs_operational_note_lines()
+        ),
+        session_prompt_rule_lines=(
+            _read_string_tuple(session_prompt_table, "working_rules") or _default_session_prompt_rule_lines()
+        ),
         plans_directory=_read_optional_string(manifest_data, "plans_directory") or "~/.codex/plans",
     )
 
@@ -163,6 +187,9 @@ def _render_workspace_agents(manifest: WorkspaceCockpitManifest) -> str:
     sync_command = f"uv --directory {devkit_repo.path} run platform workspace sync-cockpit-root --config workspace-cockpit.toml"
     repo_map_lines = "\n".join(_format_repo_map_line(repo) for repo in primary_repos)
     upstream_lines = "\n".join(_format_repo_map_line(repo) for repo in upstream_repos)
+    first_read_lines = _render_markdown_bullets(manifest.agents_first_read_lines)
+    ownership_lines = _render_markdown_bullets(manifest.agents_ownership_lines)
+    notes_lines = _render_markdown_bullets(manifest.agents_notes_lines)
     return (
         "# Workspace Cockpit\n\n"
         "This workspace is the shared Every Code cockpit for multi-repo Odoo work.\n\n"
@@ -178,34 +205,13 @@ def _render_workspace_agents(manifest: WorkspaceCockpitManifest) -> str:
         "layering, `/venv` ownership, addon path shaping, browser/devtools tooling, or\n"
         "image publish/promotion mechanics.\n\n"
         "## First reads\n\n"
-        "- Open [docs/README.md](docs/README.md) in this workspace root first.\n"
-        f"- Use [{devkit_repo.path}/AGENTS.md]({devkit_repo.path}/AGENTS.md) for the canonical\n"
-        "  shared operating guide.\n"
-        f"- Use [{devkit_repo.path}/docs/README.md]({devkit_repo.path}/docs/README.md) for the\n"
-        "  canonical shared docs index.\n"
+        f"{first_read_lines}"
         f"- Refresh this cockpit with `{sync_command}`.\n"
-        f"- Inspect cockpit drift with `{_status_command(devkit_repo)}`.\n"
-        "- Use the tenant-specific `workspace.toml` manifests when you need to run\n"
-        "  current local runtime commands through `odoo-devkit`.\n\n"
+        f"- Inspect cockpit drift with `{_status_command(devkit_repo)}`.\n\n"
         "## Ownership split\n\n"
-        "- `odoo-devkit` owns shared DX/runtime/workspace behavior plus local runtime\n"
-        "  and explicit data workflows.\n"
-        "- `odoo-control-plane` owns remote release actions, deployment truth, release\n"
-        "  tuples, and promotion evidence.\n"
-        "- Stable remote lanes are `testing` and `prod`.\n"
-        "- Harbor PR previews replace any durable shared `dev` lane.\n\n"
+        f"{ownership_lines}\n"
         "## Notes\n\n"
-        "- This cockpit root is regenerated from `workspace-cockpit.toml` through\n"
-        "  `odoo-devkit`; keep the repo map and root guidance in that config instead\n"
-        "  of hand-editing markdown entrypoints.\n"
-        "- This is still a manual multi-repo cockpit root, not a tenant\n"
-        "  `platform workspace sync` surface with runtime materialization.\n"
-        "- Do not bring `odoo-ai` into the normal workspace context. If an explicit\n"
-        "  archaeology task still needs it, treat that as an external reference rather\n"
-        "  than part of the active repo map.\n"
-        "- Commit as you go when a coherent slice is verified; prefer small,\n"
-        "  reviewable commits over batching unrelated work until the end of the\n"
-        "  session.\n"
+        f"{notes_lines}"
     )
 
 
@@ -220,6 +226,9 @@ def _render_workspace_docs_index(manifest: WorkspaceCockpitManifest) -> str:
         f"- {repo.label}: [{_docs_link_target(repo.path)}]({_docs_link_target(repo.path)})" for repo in upstream_repos
     )
     sync_command = f"uv --directory {devkit_repo.path} run platform workspace sync-cockpit-root --config workspace-cockpit.toml"
+    external_reference_lines = _render_markdown_bullets(manifest.docs_external_reference_lines)
+    working_split_lines = _render_markdown_bullets(manifest.docs_working_split_lines)
+    operational_note_lines = _render_markdown_bullets(manifest.docs_operational_note_lines)
     return (
         "# Workspace Docs\n\n"
         "Use this workspace root when the session needs to reason about or edit\n"
@@ -238,22 +247,13 @@ def _render_workspace_docs_index(manifest: WorkspaceCockpitManifest) -> str:
         "promotion behavior. They support the main system, but they are not the center\n"
         "of gravity for normal tenant/control-plane/devkit work.\n\n"
         "## External reference boundary\n\n"
-        "- Keep the main working set in the repos above.\n"
-        "- Do not include `odoo-ai` in the normal workspace flow. If an explicit\n"
-        "  archaeology task still needs it, treat that checkout as an external\n"
-        "  reference rather than part of the live repo map.\n\n"
+        f"{external_reference_lines}\n"
         "## Working split\n\n"
-        "- Use `odoo-devkit` for shared DX/runtime/workspace behavior and for local\n"
-        "  runtime plus explicit data workflows.\n"
-        "- Use `odoo-control-plane` for remote release actions, deployment truth,\n"
-        "  release tuples, and promotion evidence.\n"
-        "- Stable remote lanes are `testing` and `prod`.\n"
-        "- Harbor PR previews replace any durable shared `dev` lane.\n\n"
+        f"{working_split_lines}\n"
         "## Operational notes\n\n"
         f"- This cockpit root is regenerated from `workspace-cockpit.toml` via `{sync_command}`.\n"
         f"- Inspect whether the root docs are current with `{_status_command(devkit_repo)}`.\n"
-        "- Historical plans remain available under `/Users/cbusillo/.codex/plans/`\n"
-        "  when you need rationale or prior sequencing.\n\n"
+        f"{operational_note_lines}\n"
         "## Session prompt helper\n\n"
         "- Use [session-prompt.md](session-prompt.md) as the starting prompt template\n"
         "  for a new multi-repo Every Code session.\n"
@@ -263,6 +263,7 @@ def _render_workspace_docs_index(manifest: WorkspaceCockpitManifest) -> str:
 def _render_workspace_session_prompt(manifest: WorkspaceCockpitManifest) -> str:
     primary_repos = _repos_for_group(manifest, "primary")
     repo_map_lines = "\n".join(f"- {repo.path} -> {repo.repo_name}" for repo in primary_repos)
+    working_rule_lines = _render_plain_bullets(manifest.session_prompt_rule_lines)
     return (
         "# Session Prompt Template\n\n"
         "Use this as a starting prompt for a new multi-repo Every Code session from the\n"
@@ -275,19 +276,7 @@ def _render_workspace_session_prompt(manifest: WorkspaceCockpitManifest) -> str:
         "Repo map:\n"
         f"{repo_map_lines}\n\n"
         "Working rules:\n"
-        "- Treat repos under sources/ as the primary system under construction.\n"
-        "- Use odoo-devkit for shared DX/runtime/workspace behavior and local/data\n"
-        "  workflows.\n"
-        "- Use odoo-control-plane for remote release actions, deployment truth,\n"
-        "  release tuples, and promotion evidence.\n"
-        "- Stable remote lanes are testing and prod.\n"
-        "- Harbor PR previews replace any durable shared dev lane.\n"
-        "- Do not bring odoo-ai into the normal workspace context unless the task is\n"
-        "  explicit archaeology.\n"
-        "- Keep tenant repos thin and tenant-specific; fix shared behavior in devkit.\n"
-        "- When `workspace-cockpit.toml`, the workspace root, and source repos\n"
-        "  disagree, treat the source repos as the source of truth, then regenerate\n"
-        "  the cockpit.\n\n"
+        f"{working_rule_lines}\n"
         "When you change behavior, update the relevant source-repo docs in the same\n"
         "slice.\n"
         "```\n"
@@ -325,6 +314,76 @@ def _status_command(devkit_repo: WorkspaceCockpitRepoDefinition) -> str:
     return f"uv --directory {devkit_repo.path} run platform workspace status-cockpit-root --config workspace-cockpit.toml"
 
 
+def _render_markdown_bullets(lines: tuple[str, ...]) -> str:
+    return "".join(f"- {line}\n" for line in lines)
+
+
+def _render_plain_bullets(lines: tuple[str, ...]) -> str:
+    return "".join(f"- {line}\n" for line in lines)
+
+
+def _default_agents_first_read_lines() -> tuple[str, ...]:
+    return (
+        "Open [docs/README.md](docs/README.md) in this workspace root first.",
+        "Use [sources/devkit/AGENTS.md](sources/devkit/AGENTS.md) for the canonical shared operating guide.",
+        "Use [sources/devkit/docs/README.md](sources/devkit/docs/README.md) for the canonical shared docs index.",
+        "Use the tenant-specific `workspace.toml` manifests when you need to run current local runtime commands through `odoo-devkit`.",
+    )
+
+
+def _default_agents_ownership_lines() -> tuple[str, ...]:
+    return (
+        "`odoo-devkit` owns shared DX/runtime/workspace behavior plus local runtime and explicit data workflows.",
+        "`odoo-control-plane` owns remote release actions, deployment truth, release tuples, and promotion evidence.",
+        "Stable remote lanes are `testing` and `prod`.",
+        "Harbor PR previews replace any durable shared `dev` lane.",
+    )
+
+
+def _default_agents_note_lines() -> tuple[str, ...]:
+    return (
+        "This cockpit root is regenerated from `workspace-cockpit.toml` through `odoo-devkit`; keep the repo map and root guidance in that config instead of hand-editing markdown entrypoints.",
+        "This is still a manual multi-repo cockpit root, not a tenant `platform workspace sync` surface with runtime materialization.",
+        "Do not bring `odoo-ai` into the normal workspace context. If an explicit archaeology task still needs it, treat that as an external reference rather than part of the active repo map.",
+        "Commit as you go when a coherent slice is verified; prefer small, reviewable commits over batching unrelated work until the end of the session.",
+    )
+
+
+def _default_docs_external_reference_lines() -> tuple[str, ...]:
+    return (
+        "Keep the main working set in the repos above.",
+        "Do not include `odoo-ai` in the normal workspace flow. If an explicit archaeology task still needs it, treat that checkout as an external reference rather than part of the live repo map.",
+    )
+
+
+def _default_docs_working_split_lines() -> tuple[str, ...]:
+    return (
+        "Use `odoo-devkit` for shared DX/runtime/workspace behavior and for local runtime plus explicit data workflows.",
+        "Use `odoo-control-plane` for remote release actions, deployment truth, release tuples, and promotion evidence.",
+        "Stable remote lanes are `testing` and `prod`.",
+        "Harbor PR previews replace any durable shared `dev` lane.",
+    )
+
+
+def _default_docs_operational_note_lines() -> tuple[str, ...]:
+    return (
+        "Historical plans remain available under `/Users/cbusillo/.codex/plans/` when you need rationale or prior sequencing.",
+    )
+
+
+def _default_session_prompt_rule_lines() -> tuple[str, ...]:
+    return (
+        "Treat repos under sources/ as the primary system under construction.",
+        "Use odoo-devkit for shared DX/runtime/workspace behavior and local/data workflows.",
+        "Use odoo-control-plane for remote release actions, deployment truth, release tuples, and promotion evidence.",
+        "Stable remote lanes are testing and prod.",
+        "Harbor PR previews replace any durable shared dev lane.",
+        "Do not bring odoo-ai into the normal workspace context unless the task is explicit archaeology.",
+        "Keep tenant repos thin and tenant-specific; fix shared behavior in devkit.",
+        "When `workspace-cockpit.toml`, the workspace root, and source repos disagree, treat the source repos as the source of truth, then regenerate the cockpit.",
+    )
+
+
 def _docs_link_target(path: str) -> str:
     return (Path("..") / Path(path)).as_posix()
 
@@ -343,3 +402,21 @@ def _read_optional_string(source: dict[str, object], key: str) -> str | None:
     if not isinstance(value, str):
         raise ValueError(f"Expected {key} to be a string when present")
     return value
+
+
+def _read_optional_table(source: dict[str, object], key: str) -> dict[str, object]:
+    value = source.get(key)
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError(f"Expected {key} to be a table when present")
+    return value
+
+
+def _read_string_tuple(source: dict[str, object], key: str) -> tuple[str, ...]:
+    value = source.get(key)
+    if value is None:
+        return ()
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ValueError(f"Expected {key} to be a string array")
+    return tuple(value)

--- a/templates/workspace-cockpit/workspace-cockpit.toml
+++ b/templates/workspace-cockpit/workspace-cockpit.toml
@@ -1,6 +1,53 @@
 schema_version = 1
 plans_directory = "~/.codex/plans"
 
+[guidance.agents]
+first_reads = [
+  "Open [docs/README.md](docs/README.md) in this workspace root first.",
+  "Use [sources/devkit/AGENTS.md](sources/devkit/AGENTS.md) for the canonical shared operating guide.",
+  "Use [sources/devkit/docs/README.md](sources/devkit/docs/README.md) for the canonical shared docs index.",
+  "Use the tenant-specific `workspace.toml` manifests when you need to run current local runtime commands through `odoo-devkit`.",
+]
+ownership = [
+  "`odoo-devkit` owns shared DX/runtime/workspace behavior plus local runtime and explicit data workflows.",
+  "`odoo-control-plane` owns remote release actions, deployment truth, release tuples, and promotion evidence.",
+  "Stable remote lanes are `testing` and `prod`.",
+  "Harbor PR previews replace any durable shared `dev` lane.",
+]
+notes = [
+  "This cockpit root is regenerated from `workspace-cockpit.toml` through `odoo-devkit`; keep the repo map and root guidance in that config instead of hand-editing markdown entrypoints.",
+  "This is still a manual multi-repo cockpit root, not a tenant `platform workspace sync` surface with runtime materialization.",
+  "Do not bring `odoo-ai` into the normal workspace context. If an explicit archaeology task still needs it, treat that as an external reference rather than part of the active repo map.",
+  "Commit as you go when a coherent slice is verified; prefer small, reviewable commits over batching unrelated work until the end of the session.",
+]
+
+[guidance.docs]
+external_reference_boundary = [
+  "Keep the main working set in the repos above.",
+  "Do not include `odoo-ai` in the normal workspace flow. If an explicit archaeology task still needs it, treat that checkout as an external reference rather than part of the live repo map.",
+]
+working_split = [
+  "Use `odoo-devkit` for shared DX/runtime/workspace behavior and for local runtime plus explicit data workflows.",
+  "Use `odoo-control-plane` for remote release actions, deployment truth, release tuples, and promotion evidence.",
+  "Stable remote lanes are `testing` and `prod`.",
+  "Harbor PR previews replace any durable shared `dev` lane.",
+]
+operational_notes = [
+  "Historical plans remain available under `/Users/cbusillo/.codex/plans/` when you need rationale or prior sequencing.",
+]
+
+[guidance.session_prompt]
+working_rules = [
+  "Treat repos under sources/ as the primary system under construction.",
+  "Use odoo-devkit for shared DX/runtime/workspace behavior and local/data workflows.",
+  "Use odoo-control-plane for remote release actions, deployment truth, release tuples, and promotion evidence.",
+  "Stable remote lanes are testing and prod.",
+  "Harbor PR previews replace any durable shared dev lane.",
+  "Do not bring odoo-ai into the normal workspace context unless the task is explicit archaeology.",
+  "Keep tenant repos thin and tenant-specific; fix shared behavior in devkit.",
+  "When `workspace-cockpit.toml`, the workspace root, and source repos disagree, treat the source repos as the source of truth, then regenerate the cockpit.",
+]
+
 [[repos]]
 group = "primary"
 role = "devkit"

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -193,6 +193,9 @@ repo_name = "odoo-control-plane"
             session_prompt_text = (output_directory / "docs" / "session-prompt.md").read_text(encoding="utf-8")
 
             self.assertIn('path = "sources/devkit"', manifest_text)
+            self.assertIn("[guidance.agents]", manifest_text)
+            self.assertIn("[guidance.docs]", manifest_text)
+            self.assertIn("[guidance.session_prompt]", manifest_text)
             self.assertIn("sources/devkit/AGENTS.md", agents_text)
             self.assertIn("sources/devkit/docs/README.md", agents_text)
             self.assertIn("Shared operating guide", docs_index_text)
@@ -308,6 +311,56 @@ repo_name = "odoo-control-plane"
             stale_agents_status = next(file_status for file_status in stale_result.file_statuses if file_status.path.name == "AGENTS.md")
             self.assertTrue(stale_agents_status.exists)
             self.assertFalse(stale_agents_status.matches_expected)
+
+    def test_workspace_cockpit_sync_renders_guidance_from_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output_directory = Path(temporary_directory)
+            manifest_path = output_directory / "workspace-cockpit.toml"
+            manifest_path.write_text(
+                """
+schema_version = 1
+
+[guidance.agents]
+first_reads = ["Open the custom cockpit guide first."]
+ownership = ["Custom ownership line."]
+notes = ["Custom note line."]
+
+[guidance.docs]
+external_reference_boundary = ["Custom external boundary."]
+working_split = ["Custom working split."]
+operational_notes = ["Custom operational note."]
+
+[guidance.session_prompt]
+working_rules = ["Custom working rule."]
+
+[[repos]]
+group = "primary"
+role = "devkit"
+label = "Devkit"
+path = "sources/devkit"
+repo_name = "odoo-devkit"
+
+[[repos]]
+group = "primary"
+role = "control_plane"
+label = "Control plane"
+path = "sources/control-plane"
+repo_name = "odoo-control-plane"
+""".lstrip(),
+                encoding="utf-8",
+            )
+
+            sync_workspace_cockpit(
+                manifest=load_workspace_cockpit_manifest(manifest_path),
+                output_directory=output_directory,
+                overwrite_existing=True,
+            )
+
+            self.assertIn("Open the custom cockpit guide first.", (output_directory / "AGENTS.md").read_text(encoding="utf-8"))
+            self.assertIn("Custom ownership line.", (output_directory / "AGENTS.md").read_text(encoding="utf-8"))
+            self.assertIn("Custom external boundary.", (output_directory / "docs" / "README.md").read_text(encoding="utf-8"))
+            self.assertIn("Custom working split.", (output_directory / "docs" / "README.md").read_text(encoding="utf-8"))
+            self.assertIn("Custom working rule.", (output_directory / "docs" / "session-prompt.md").read_text(encoding="utf-8"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend `workspace-cockpit.toml` so section-level cockpit guidance lives in config alongside the repo map
- render AGENTS, docs index, and session-prompt guidance from structured config tables instead of only from code defaults
- keep the current Odoo cockpit language as the default/template while allowing future cockpit roots to own those bullets explicitly

## Verification
- `uv run python -m unittest tests.test_scaffold`
- `uv run python -m unittest tests.test_workspace tests.test_scaffold`
- `uv run platform workspace scaffold-cockpit-root --output-dir /Users/cbusillo/Developer/odoo-workspaces/migration --force`
- `uv run platform workspace status-cockpit-root --config /Users/cbusillo/Developer/odoo-workspaces/migration/workspace-cockpit.toml`