### PR TITLE
Tighten devkit workspace docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ The current workspace flow:
 
 For remote environments, the stable lane model is `testing` plus `prod`.
 Harbor-managed PR previews are a separate control-plane concern rather than a
-third durable runtime lane exposed through `platform runtime`.
+third durable runtime lane exposed through `platform runtime`. Remote release
+or promotion flow is artifact-backed and belongs in `odoo-control-plane`, not
+in branch-oriented `odoo-devkit` commands.
 
 ## Command surface
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,7 +4,8 @@ title: Workspace Architecture
 
 Purpose
 
-- Capture the workspace-first architecture for extracted tenant workspaces.
+- Capture the workspace-first architecture for the current tenant workspace
+  model.
 - Make the ownership split explicit between the tenant repo, `odoo-devkit`,
   the materialized workspace root, and the control plane.
 
@@ -19,6 +20,8 @@ When
 - `odoo-devkit` owns the shared DX/runtime/bootstrap contract.
 - The control plane owns canonical deploy/build tuples and release-sensitive
   behavior.
+- Remote release flow remains artifact-backed and control-plane-owned rather
+  than branch-driven inside `odoo-devkit`.
 - Stable remote lanes live in the control-plane shape as `testing` and `prod`;
   Harbor PR previews are separate preview records and runtime state, not a
   durable third lane owned by `odoo-devkit`.
@@ -31,8 +34,7 @@ When
 - Tenant-specific docs and domain notes.
 - Tracked `workspace.toml` input for local DX defaults.
 - Thin repo-root instructions only.
-- Use `templates/tenant-overlay/` as the starting shape for extracted tenant
-  repos.
+- Use `templates/tenant-overlay/` as the starting shape for thin tenant repos.
 
 ### `odoo-devkit`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ preview lifecycle for stable remote lanes live in `odoo-control-plane`.
 - [tooling/command-patterns.md](tooling/command-patterns.md) for concrete
   workspace command examples.
 - [tooling/tenant-overlay.md](tooling/tenant-overlay.md) for the thin tenant
-  repo shape used by the split.
+  repo shape used by the current workspace model.
 
 ## Shared Responsibilities
 

--- a/docs/tooling/tenant-overlay.md
+++ b/docs/tooling/tenant-overlay.md
@@ -2,7 +2,8 @@
 
 Purpose
 
-- Define the thin repo-root shape a tenant repo keeps in the split workspace.
+- Define the thin repo-root shape a tenant repo keeps in the current workspace
+  model.
 
 When
 
@@ -53,8 +54,11 @@ When
   through an explicit runtime `--instance` override.
 - Release actions for remote environments still belong in
   `odoo-control-plane`, not in tenant-root `platform runtime` commands.
-- The generated run configurations and shell helpers call
-  `uv --directory ../odoo-devkit run platform ...`.
+- The generated `Workspace Sync` and `Workspace Status` entrypoints call the
+  tenant-root helper scripts so the manifest stays anchored at the tenant repo
+  root.
+- Runtime run configurations continue to call
+  `uv --directory ../odoo-devkit run platform ...` directly.
 - For terminal use, tenant repos should prefer `./scripts/workspace-sync`
   and `./scripts/workspace-status` as anchored convenience commands so the
   manifest path stays tied to the tenant repo root.

--- a/docs/tooling/workspace-cli.md
+++ b/docs/tooling/workspace-cli.md
@@ -136,7 +136,7 @@ Purpose
 
 - Copy the thin tenant-overlay starter files into a target repo directory.
 - Stamp the tenant slug into the starter `workspace.toml`.
-- Give the first extracted tenant repo a repeatable thin-root starting point.
+- Give a tenant repo a repeatable thin-root starting point.
 - Keep the starter aligned with the flat tenant-addon rule: tenant-owned addons
   live directly under `addons/`, while shared addons stay external via
   `[repos.shared_addons]`.

--- a/odoo_devkit/workspace_surface.py
+++ b/odoo_devkit/workspace_surface.py
@@ -158,7 +158,7 @@ def _render_workspace_docs_index(
         label="Tenant docs",
         relative_target=Path("../sources/tenant/docs/README.md"),
         absolute_target=tenant_repo_path / "docs" / "README.md",
-        fallback_text="Tenant docs index is not present yet; keep tenant-specific notes in the tenant repo as they are extracted.",
+        fallback_text="Tenant docs index is not present yet; keep tenant-specific notes in the tenant repo.",
     )
     shared_devkit_docs_line = _render_optional_link_line(
         label="Shared devkit docs",


### PR DESCRIPTION
$'## Summary
- remove a few transition-era phrases from the devkit docs and generated workspace-doc fallback text
- make the control-plane boundary explicit for remote artifact-backed release flow
- document that tenant Workspace Sync and Workspace Status entrypoints anchor through the tenant helper scripts

## Verification
- uv run python -m unittest discover -s tests'