### PR TITLE
Reconcile docs metadata and cockpit guidance

### DIFF
--- a/.github/github-repo-workflow.json
+++ b/.github/github-repo-workflow.json
@@ -54,6 +54,8 @@
   "deployLabels": [],
   "healthUrls": [],
   "relatedRepos": [
+    "disable_odoo_online",
+    "odoo-docker",
     "odoo-shared-addons",
     "odoo-tenant-cm",
     "odoo-tenant-opw",

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ preview lifecycle for stable remote lanes live in `launchplane`.
 - [tooling/workspace-cli.md](tooling/workspace-cli.md) for the workspace
   command surface and generated-output contract.
 - [tooling/artifact-inputs.md](tooling/artifact-inputs.md) for the repo-owned
-  publish input manifest shape.
+  runtime and publish source-input contract.
 - [tooling/command-patterns.md](tooling/command-patterns.md) for concrete
   workspace command examples.
 - [tooling/tenant-overlay.md](tooling/tenant-overlay.md) for the thin tenant

--- a/docs/tooling/workspace-cli.md
+++ b/docs/tooling/workspace-cli.md
@@ -81,7 +81,8 @@ Purpose
 Purpose
 
 - Report whether the workspace exists.
-- Report whether the lock file and workspace-root docs surface exist.
+- Report whether the lock file and workspace-root cockpit files exist:
+  `AGENTS.md`, `docs/README.md`, and `docs/session-prompt.md`.
 - Report the tenant/devkit/shared-addons source paths and attached IDE roots.
 
 ## `workspace scaffold-cockpit-root`

--- a/odoo_devkit/workspace_cockpit.py
+++ b/odoo_devkit/workspace_cockpit.py
@@ -377,7 +377,7 @@ def _default_session_prompt_rule_lines() -> tuple[str, ...]:
         "Launchplane PR previews replace any durable shared dev lane.",
         "Do not bring odoo-ai into the normal workspace context unless the task is explicit archaeology.",
         "Keep tenant repos thin and tenant-specific; fix shared behavior in devkit.",
-        "When `workspace-cockpit.toml`, the workspace root, and source repos disagree, treat the source repos as the source of truth, then regenerate the cockpit.",
+        "When cockpit-root files disagree, update `workspace-cockpit.toml` for cockpit guidance or the relevant source repo for repo-owned code/docs, then regenerate the cockpit.",
     )
 
 

--- a/templates/workspace-cockpit/workspace-cockpit.toml
+++ b/templates/workspace-cockpit/workspace-cockpit.toml
@@ -46,7 +46,7 @@ working_rules = [
   "Launchplane PR previews replace any durable shared dev lane.",
   "Do not bring odoo-ai into the normal workspace context unless the task is explicit archaeology.",
   "Keep tenant repos thin and tenant-specific; fix shared behavior in devkit.",
-  "When `workspace-cockpit.toml`, the workspace root, and source repos disagree, treat the source repos as the source of truth, then regenerate the cockpit.",
+  "When cockpit-root files disagree, update `workspace-cockpit.toml` for cockpit guidance or the relevant source repo for repo-owned code/docs, then regenerate the cockpit.",
 ]
 
 [[repos]]

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -209,7 +209,8 @@ repo_name = "harbor"
             self.assertIn("workspace-cockpit.toml", agents_text)
             self.assertIn("uv --project sources/devkit", agents_text)
             self.assertIn("status-cockpit-root", agents_text)
-            self.assertIn("workspace root, and source repos", session_prompt_text)
+            self.assertIn("When cockpit-root files disagree", session_prompt_text)
+            self.assertIn("repo-owned code/docs", session_prompt_text)
             self.assertIn("launchplane for remote release actions", session_prompt_text)
 
 
@@ -272,9 +273,9 @@ repo_name = "odoo-docker"
             self.assertIn("sources/shared-addons", agents_text)
             self.assertIn("AGENTS.override.md", agents_text)
             self.assertIn("Public base image", (output_directory / "docs" / "README.md").read_text(encoding="utf-8"))
-            self.assertIn(
-                "source repos as the source of truth", (output_directory / "docs" / "session-prompt.md").read_text(encoding="utf-8")
-            )
+            session_prompt_text = (output_directory / "docs" / "session-prompt.md").read_text(encoding="utf-8")
+            self.assertIn("workspace-cockpit.toml", session_prompt_text)
+            self.assertIn("repo-owned code/docs", session_prompt_text)
 
     def test_workspace_cockpit_status_reports_current_missing_and_stale_files(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:


### PR DESCRIPTION
## Summary

- clarify the docs index entry for `artifact-inputs.toml` as a runtime and publish source-input contract
- make `workspace status` docs name the generated cockpit files it checks
- correct manual cockpit guidance so `workspace-cockpit.toml` owns cockpit-root guidance while source repos own their code/docs
- add `disable_odoo_online` and `odoo-docker` to repo workflow metadata related repos after #25 planning identified them as dependency-policy inputs

Refs #23

## Verification

- `uv run ruff check --diff .`
- `uv run ruff format --diff .`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run python -m unittest tests.test_scaffold`
- `uv run python -m unittest discover -s tests`
- `uv run platform --help`
- `uv build`
- `uv run platform workspace scaffold-cockpit-root --output-dir <tmp>/cockpit --force`
- inspected generated cockpit `docs/session-prompt.md`
- `uv run platform workspace sync --manifest /Users/cbusillo/Developer/odoo-tenant-cm/workspace.toml`
- inspected generated CM workspace `AGENTS.md`, `docs/README.md`, and `docs/session-prompt.md`

## Notes

This is the second narrow cleanup slice for #23. It keeps implementation behavior unchanged and does not attempt to close the broader cleanup issue.
