### PR TITLE
Refresh PyCharm repo mappings

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/../odoo-control-plane/.idea/odoo-control-plane.iml" filepath="$PROJECT_DIR$/../odoo-control-plane/.idea/odoo-control-plane.iml" />
+      <module fileurl="file://$PROJECT_DIR$/../launchplane/.idea/launchplane.iml" filepath="$PROJECT_DIR$/../launchplane/.idea/launchplane.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/odoo-devkit.iml" filepath="$PROJECT_DIR$/.idea/odoo-devkit.iml" />
       <module fileurl="file://$PROJECT_DIR$/../odoo-docker/.idea/odoo-docker.iml" filepath="$PROJECT_DIR$/../odoo-docker/.idea/odoo-docker.iml" />
       <module fileurl="file://$PROJECT_DIR$/../odoo-enterprise-docker/.idea/odoo-enterprise-docker.iml" filepath="$PROJECT_DIR$/../odoo-enterprise-docker/.idea/odoo-enterprise-docker.iml" />

--- a/.idea/odoo-devkit.iml
+++ b/.idea/odoo-devkit.iml
@@ -7,7 +7,7 @@
     </content>
     <orderEntry type="jdk" jdkName="uv (odoo-devkit)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="module" module-name="odoo-control-plane" />
+    <orderEntry type="module" module-name="launchplane" />
     <orderEntry type="module" module-name="odoo-docker" />
     <orderEntry type="module" module-name="odoo-enterprise-docker" />
   </component>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -12,7 +12,7 @@
   </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/../odoo-control-plane" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/../launchplane" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/../odoo-docker" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/../odoo-enterprise-docker" vcs="Git" />
   </component>


### PR DESCRIPTION
## Summary

- replace stale tracked PyCharm references to `../odoo-control-plane` with the current `../launchplane` repo/module
- keep the existing `odoo-docker` and `odoo-enterprise-docker` PyCharm mappings intact
- preserve this as a tiny #23 stale-config cleanup slice after the dead/generated-file inventory found no tracked build junk

Refs #23

## Verification

- `xmllint --noout .idea/modules.xml .idea/odoo-devkit.iml .idea/vcs.xml`
- `uv run ruff check --diff .`
- `uv run ruff format --diff .`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run python -m unittest discover -s tests`
- `uv run platform --help`

## Notes

The inventory did not find tracked generated build artifacts, cache directories, or ignored leftovers. Other potentially tempting files such as addon placeholders and tracked PyCharm inspection settings appear tied to existing workspace/PyCharm contracts, so this PR only removes the concrete stale control-plane mapping.
