### PR TITLE
Use github.json for workflow metadata

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -34,7 +34,11 @@
     "inspection": {
       "tool": "jetbrains",
       "ide": "PyCharm",
-      "scopePreference": ["changed_files", "directory", "whole_project"]
+      "scopePreference": [
+        "changed_files",
+        "directory",
+        "whole_project"
+      ]
     },
     "docsRequiredWhen": [
       "behavior changes",
@@ -49,7 +53,9 @@
       "PyCharm generation changes"
     ]
   },
-  "importantWorkflows": ["CI"],
+  "importantWorkflows": [
+    "CI"
+  ],
   "qaLabels": [],
   "deployLabels": [],
   "healthUrls": [],
@@ -61,7 +67,6 @@
     "odoo-tenant-opw",
     "launchplane"
   ],
-  "validatedThrough": ["odoo-tenant-cm", "odoo-tenant-opw"],
   "githubSignals": {
     "postMerge": {
       "waitForActions": true,
@@ -91,7 +96,6 @@
       "primary commands change",
       "important workflows change",
       "repo relationship changes",
-      "validated-through repos change",
       "cleanup policy changes",
       "ownership boundaries change",
       "workspace manifest contract changes",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ into the generated workspace root.
 
 ## Validation
 
-- Use [`.github/github-repo-workflow.json`](.github/github-repo-workflow.json)
+- Use [`.github/github.json`](.github/github.json)
   for validation commands and quality gates.
 - For workspace-surface changes, also run a live `workspace sync` against the
   current proof manifest and inspect the generated root files, including


### PR DESCRIPTION
## Summary
- rename repo workflow metadata from `.github/github-repo-workflow.json` to `.github/github.json`
- update local guidance/docs to point at the canonical metadata path
- drop retired `validatedThrough` metadata while preserving the rest of the workflow facts

## Validation
- `jq empty .github/github.json`
- confirmed `.github/github-repo-workflow.json` is removed
- confirmed repo docs no longer reference `.github/github-repo-workflow.json`
- confirmed `.github/github.json` has no `validatedThrough` / `validated-through` entries
- compared old and new JSON content, allowing only the retired `validatedThrough` field/trigger removal
- `git diff --check`
