### PR TITLE
Align workspace cockpit naming

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ preview lifecycle for stable remote lanes live in `launchplane`.
 - [../README.md](../README.md) for the current bootstrap scope and command
   surface.
 - [ARCHITECTURE.md](ARCHITECTURE.md) for the workspace-first ownership model.
-- [roles.md](roles.md) for shared Codex role expectations.
+- [roles.md](roles.md) for shared Every Code role expectations.
 - [tooling/workspace-cli.md](tooling/workspace-cli.md) for the workspace
   command surface and generated-output contract.
 - [tooling/artifact-inputs.md](tooling/artifact-inputs.md) for the repo-owned

--- a/docs/roles.md
+++ b/docs/roles.md
@@ -4,7 +4,7 @@ title: Shared Roles
 
 Purpose
 
-- Define role expectations and outputs for Codex work that applies across
+- Define role expectations and outputs for Every Code work that applies across
   tenant repos and the generated workspace root.
 
 When

--- a/odoo_devkit/workspace_cockpit.py
+++ b/odoo_devkit/workspace_cockpit.py
@@ -26,7 +26,7 @@ class WorkspaceCockpitManifest:
     docs_working_split_lines: tuple[str, ...]
     docs_operational_note_lines: tuple[str, ...]
     session_prompt_rule_lines: tuple[str, ...]
-    plans_directory: str = "~/.codex/plans"
+    plans_directory: str = "~/.code/plans"
 
     @property
     def manifest_directory(self) -> Path:
@@ -89,7 +89,7 @@ def load_workspace_cockpit_manifest(manifest_path: Path) -> WorkspaceCockpitMani
         session_prompt_rule_lines=(
             _read_string_tuple(session_prompt_table, "working_rules") or _default_session_prompt_rule_lines()
         ),
-        plans_directory=_read_optional_string(manifest_data, "plans_directory") or "~/.codex/plans",
+        plans_directory=_read_optional_string(manifest_data, "plans_directory") or "~/.code/plans",
     )
 
 
@@ -365,7 +365,7 @@ def _default_docs_working_split_lines() -> tuple[str, ...]:
 
 
 def _default_docs_operational_note_lines() -> tuple[str, ...]:
-    return ("Historical plans remain available under `/Users/cbusillo/.codex/plans/` when you need rationale or prior sequencing.",)
+    return ("Historical plans normally live under `/Users/cbusillo/.code/plans/`; check `/Users/cbusillo/.codex/plans/` only for legacy rationale or prior sequencing.",)
 
 
 def _default_session_prompt_rule_lines() -> tuple[str, ...]:

--- a/templates/workspace-cockpit/workspace-cockpit.toml
+++ b/templates/workspace-cockpit/workspace-cockpit.toml
@@ -1,5 +1,5 @@
 schema_version = 1
-plans_directory = "~/.codex/plans"
+plans_directory = "~/.code/plans"
 
 [guidance.agents]
 first_reads = [
@@ -34,7 +34,7 @@ working_split = [
   "Launchplane PR previews replace any durable shared `dev` lane.",
 ]
 operational_notes = [
-  "Historical plans remain available under `/Users/cbusillo/.codex/plans/` when you need rationale or prior sequencing.",
+  "Historical plans normally live under `/Users/cbusillo/.code/plans/`; check `/Users/cbusillo/.codex/plans/` only for legacy rationale or prior sequencing.",
 ]
 
 [guidance.session_prompt]


### PR DESCRIPTION
## Summary
- update shared role docs from Codex wording to Every Code wording
- make workspace cockpit plan defaults use `~/.code/plans`
- keep `~/.codex/plans` documented only as a legacy lookup location

## Validation
- git diff --check
- uv run python -m unittest discover -s tests

Refs cbusillo/code#186
