### PR TITLE
Align devkit with Launchplane runtime health

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,11 @@ Current runtime ownership is intentionally narrow and explicit:
 - The shared tenant compose database service stays pinned to `postgres:17`
   while existing tenant DB volumes still use the legacy
   `/var/lib/postgresql/data` layout.
+- The shared local compose contract includes the image-owned Launchplane runtime
+  addon root `/opt/launchplane/addons` and loads
+  `base,web,launchplane_runtime_health` as server-wide modules by default.
+  `/web/health` remains the local container liveness check; Launchplane runtime
+  identity evidence is exposed by the base image at `/launchplane/health`.
 - A Postgres major-version bump is not a routine dependency refresh on this
   surface. Treat it as explicit migration work with a documented upgrade path
   for existing tenant data volumes.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,8 @@ x-odoo-env: &odoo-env
   ODOO_DEV_MODE: ${ODOO_DEV_MODE:-}
   ODOO_INSTALL_MODULES: ${ODOO_INSTALL_MODULES:-}
   ODOO_UPDATE_MODULES: ${ODOO_UPDATE_MODULES:-AUTO}
-  ODOO_ADDONS_PATH: ${ODOO_ADDONS_PATH:-/opt/project/addons,/opt/extra_addons,/opt/enterprise,/odoo/addons}
+  ODOO_ADDONS_PATH: ${ODOO_ADDONS_PATH:-/opt/project/addons,/opt/extra_addons,/opt/launchplane/addons,/opt/enterprise,/odoo/addons}
+  ODOO_SERVER_WIDE_MODULES: ${ODOO_SERVER_WIDE_MODULES:-base,web,launchplane_runtime_health}
   ODOO_DATA_WORKFLOW_LOCK_FILE: ${ODOO_DATA_WORKFLOW_LOCK_FILE:-/volumes/data/.data_workflow_in_progress}
   ODOO_DATA_WORKFLOW_LOCK_TIMEOUT_SECONDS: ${ODOO_DATA_WORKFLOW_LOCK_TIMEOUT_SECONDS:-7200}
   IMAGE_ODOO_ENTERPRISE_LOCATION: /volumes/enterprise_disabled


### PR DESCRIPTION
## Summary
- include /opt/launchplane/addons in local Odoo compose defaults
- load base,web,launchplane_runtime_health as the default server-wide module set
- document the split between /web/health liveness and /launchplane/health Launchplane evidence

## Validation
- uv run python -m unittest tests.test_compose_contract

## Rollout note
This can merge after the odoo-docker runtime addon PR is accepted. It aligns local/devkit defaults with the new base image contract.