### PR TITLE
Include Launchplane addons in runtime stack path

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ Current runtime ownership is intentionally narrow and explicit:
 - The shared local compose contract includes the image-owned Launchplane runtime
   addon root `/opt/launchplane/addons` and loads
   `base,web,launchplane_runtime_health` as server-wide modules by default.
+  Keep that addon root in the rendered `ODOO_ADDONS_PATH` so startup scripts,
+  generated Odoo config, and wrapper-normalized server commands agree.
   `/web/health` remains the local container liveness check; Launchplane runtime
   identity evidence is exposed by the base image at `/launchplane/health`.
 - A Postgres major-version bump is not a routine dependency refresh on this

--- a/platform/stack.toml
+++ b/platform/stack.toml
@@ -5,6 +5,7 @@ addons_path = [
     "/odoo/odoo/addons",
     "/opt/project/addons",
     "/opt/extra_addons",
+    "/opt/launchplane/addons",
     "/opt/enterprise",
 ]
 required_env_keys = [

--- a/tests/test_ide_support.py
+++ b/tests/test_ide_support.py
@@ -25,6 +25,7 @@ class DevkitIdeSupportTests(unittest.TestCase):
                     "/odoo/odoo/addons",
                     "/opt/project/addons",
                     "/opt/extra_addons",
+                    "/opt/launchplane/addons",
                     "/opt/enterprise",
                 ),
                 source_environment={"ODOO_DB_USER": "odoo", "ODOO_DB_PASSWORD": "pw"},
@@ -33,7 +34,7 @@ class DevkitIdeSupportTests(unittest.TestCase):
             self.assertEqual(written_conf, repo_root / ".platform" / "ide" / "cm.local.odoo.conf")
             rendered_conf = written_conf.read_text(encoding="utf-8")
             self.assertIn(
-                f"addons_path = /odoo/addons,/odoo/odoo/addons,{repo_root / 'addons'},/opt/extra_addons,/opt/enterprise",
+                f"addons_path = /odoo/addons,/odoo/odoo/addons,{repo_root / 'addons'},/opt/extra_addons,/opt/launchplane/addons,/opt/enterprise",
                 rendered_conf,
             )
             self.assertNotIn("/.platform/ide/", rendered_conf)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -699,7 +699,12 @@ sources = [
             self.assertIn("DOCKER_IMAGE=odoo-opw-local", runtime_env_text)
             self.assertIn("ODOO_ADDON_REPOSITORIES=cbusillo/disable_odoo_online@main", runtime_env_text)
             self.assertIn(f"ODOO_PROJECT_ADDONS_HOST_PATH={(tenant_repo_path / 'addons').resolve()}", runtime_env_text)
-            self.assertIn("ODOO_ADDONS_PATH=/odoo/addons,/opt/project/addons,/opt/project/addons/shared", runtime_env_text)
+            addons_path_line = next(
+                line for line in runtime_env_text.splitlines() if line.startswith("ODOO_ADDONS_PATH=")
+            )
+            self.assertIn("/opt/project/addons", addons_path_line)
+            self.assertIn("/opt/project/addons/shared", addons_path_line)
+            self.assertIn("/opt/launchplane/addons", addons_path_line)
             pycharm_conf_text = pycharm_conf_file.read_text(encoding="utf-8")
             self.assertIn("db_port = 15432", pycharm_conf_text)
             self.assertIn(f"addons_path = {(tenant_repo_path / 'addons').resolve()}", pycharm_conf_text)
@@ -716,7 +721,7 @@ sources = [
                 """
 schema_version = 1
 odoo_version = "19.0"
-addons_path = ["/odoo/addons", "/opt/project/addons"]
+addons_path = ["/odoo/addons", "/opt/launchplane/addons", "/opt/project/addons"]
 addon_repository_selectors = ["cbusillo/disable_odoo_online@main"]
 required_env_keys = ["ODOO_MASTER_PASSWORD", "ODOO_DB_USER", "ODOO_DB_PASSWORD"]
 
@@ -866,10 +871,12 @@ install_modules = ["opw_custom"]
             self.assertIn("DOCKER_IMAGE=odoo-opw-local", runtime_env_text)
             self.assertIn(f"ODOO_PROJECT_ADDONS_HOST_PATH={(tenant_repo_path / 'addons').resolve()}", runtime_env_text)
             self.assertIn(f"ODOO_SHARED_ADDONS_HOST_PATH={shared_addons_repo_path.resolve()}", runtime_env_text)
-            self.assertIn(
-                "ODOO_ADDONS_PATH=/odoo/addons,/opt/project/addons,/opt/project/addons/shared",
-                runtime_env_text,
+            addons_path_line = next(
+                line for line in runtime_env_text.splitlines() if line.startswith("ODOO_ADDONS_PATH=")
             )
+            self.assertIn("/opt/project/addons", addons_path_line)
+            self.assertIn("/opt/project/addons/shared", addons_path_line)
+            self.assertIn("/opt/launchplane/addons", addons_path_line)
 
     def test_native_runtime_select_includes_website_bootstrap_payload(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -1224,7 +1231,7 @@ sources = [
                 """
 schema_version = 1
 odoo_version = "19.0"
-addons_path = ["/odoo/addons", "/opt/project/addons"]
+addons_path = ["/odoo/addons", "/opt/launchplane/addons", "/opt/project/addons"]
 addon_repository_selectors = ["cbusillo/disable_odoo_online@main"]
 required_env_keys = ["ODOO_MASTER_PASSWORD", "ODOO_DB_USER", "ODOO_DB_PASSWORD"]
 
@@ -2571,7 +2578,7 @@ attached_paths = ["sources/devkit"]
             """
 schema_version = 1
 odoo_version = "19.0"
-addons_path = ["/odoo/addons", "/opt/project/addons"]
+addons_path = ["/odoo/addons", "/opt/launchplane/addons", "/opt/project/addons"]
 required_env_keys = ["ODOO_MASTER_PASSWORD", "ODOO_DB_USER", "ODOO_DB_PASSWORD"]
 
 [contexts.opw]


### PR DESCRIPTION
## Summary
- add /opt/launchplane/addons to the shared Odoo runtime stack addon path
- document that startup/config/wrapper paths must agree on the Launchplane runtime-health addon root
- update runtime and IDE tests so generated ODOO_ADDONS_PATH includes the Launchplane addon root

## Validation
- git diff --check
- uv run python -m unittest tests.test_ide_support tests.test_runtime.RuntimeCommandTests.test_native_runtime_select_writes_runtime_env_and_pycharm_conf tests.test_runtime.RuntimeCommandTests.test_native_runtime_select_prefers_manifest_mounts_over_runtime_repo_defaults
- uv run ruff check README.md platform/stack.toml tests/test_ide_support.py tests/test_runtime.py

## Context
OPW target replacement injects Launchplane runtime identity but /launchplane/health still returns 404. The enterprise image now preserves the base addon path, but devkit still rendered ODOO_ADDONS_PATH from platform/stack.toml without /opt/launchplane/addons, so startup-generated Odoo config could hide the health addon at runtime.