### PR TITLE
Fix Odoo post-deploy website bootstrap

### DIFF
--- a/docker/scripts/odoo_website_bootstrap.py
+++ b/docker/scripts/odoo_website_bootstrap.py
@@ -4,6 +4,7 @@ import json
 import os
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 ODOO_INSTANCE_OVERRIDES_PAYLOAD_ENV_KEY = "ODOO_INSTANCE_OVERRIDES_PAYLOAD_B64"
 
@@ -148,7 +149,7 @@ def apply_website_bootstrap(env: Any, parsed_payload: dict[str, object] | None) 
     if canonical_url:
         env["ir.config_parameter"].sudo().set_param("web.base.url", canonical_url)
         env["ir.config_parameter"].sudo().set_param("web.base.url.freeze", "True")
-        website_values["domain"] = canonical_url
+        website_values["domain"] = urlparse(canonical_url).netloc or canonical_url
     default_lang = str(website_payload.get("default_lang") or "").strip()
     if default_lang and "default_lang_id" in website._fields:
         lang = env["res.lang"].sudo().search([("code", "=", default_lang)], limit=1)

--- a/docker/scripts/run_odoo_data_workflows.py
+++ b/docker/scripts/run_odoo_data_workflows.py
@@ -1509,6 +1509,7 @@ with registry.cursor() as cr:
 
     def run_post_deploy_maintenance(self) -> None:
         _logger.info("Starting post-deploy maintenance for database '%s'", self.local.db_name)
+        self.install_addons(reason="post-deploy install")
         self.update_addons(reason="post-deploy upgrade")
         self.connect_to_db()
         self.reconcile_missing_manifest_install_queue()

--- a/tests/test_odoo_data_workflows.py
+++ b/tests/test_odoo_data_workflows.py
@@ -65,6 +65,7 @@ class OdooDataWorkflowShellEnvironmentTests(unittest.TestCase):
         runner = odoo_data_workflows.OdooDataWorkflowRunner(self._local_settings(), upstream=None, env_file=None)
 
         with (
+            patch.object(runner, "install_addons", side_effect=lambda **_kwargs: calls.append("install_addons")),
             patch.object(runner, "update_addons", side_effect=lambda **_kwargs: calls.append("update_addons")),
             patch.object(runner, "connect_to_db", side_effect=lambda: calls.append("connect_to_db")),
             patch.object(
@@ -96,6 +97,7 @@ class OdooDataWorkflowShellEnvironmentTests(unittest.TestCase):
         self.assertEqual(
             calls,
             [
+                "install_addons",
                 "update_addons",
                 "connect_to_db",
                 "reconcile_missing_manifest_install_queue",

--- a/tests/test_odoo_website_bootstrap.py
+++ b/tests/test_odoo_website_bootstrap.py
@@ -116,6 +116,7 @@ class WebsiteBootstrapHelperTests(unittest.TestCase):
 
         self.assertIn({"homepage_url": "/shop", "homepage_id": False}, env.website.writes)
         self.assertEqual(env.config_parameter.values["web.base.url"], "https://opw-testing.example.com")
+        self.assertIn({"name": "OPW", "domain": "opw-testing.example.com"}, env.website.writes)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- install configured Odoo modules during post-deploy maintenance before updating existing modules
- normalize website.domain to the bare hostname while keeping web.base.url as the full canonical URL
- add focused tests for post-deploy maintenance ordering and website domain normalization

## Validation
- uv run python -m unittest tests.test_odoo_data_workflows.OdooDataWorkflowShellEnvironmentTests.test_post_deploy_maintenance_runs_overrides_and_service_user_provisioning tests.test_odoo_website_bootstrap.WebsiteBootstrapHelperTests
- uv run ruff check --diff docker/scripts/run_odoo_data_workflows.py docker/scripts/odoo_website_bootstrap.py tests/test_odoo_data_workflows.py tests/test_odoo_website_bootstrap.py
- uv run ruff check docker/scripts/run_odoo_data_workflows.py docker/scripts/odoo_website_bootstrap.py tests/test_odoo_data_workflows.py tests/test_odoo_website_bootstrap.py

Supports the cm_website/testing fixture proof: post-deploy included website_bootstrap but /cell-mechanic remained 404 because the runtime must install the configured tenant module and bind the website to the request Host.