### PR TITLE
Document CodeQL merge protection

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -62,7 +62,6 @@
   "requiredStatusChecks": ["test"],
   "codeScanningMergeProtection": {
     "ruleset": "Require code scanning results",
-    "target": "defaultBranch",
     "tool": "CodeQL",
     "alertsThreshold": "errors",
     "securityAlertsThreshold": "high_or_higher",

--- a/.github/github.json
+++ b/.github/github.json
@@ -59,11 +59,15 @@
     "Dependency Graph",
     "Dependabot Updates"
   ],
-  "requiredStatusChecks": [
-    "test",
-    "Analyze (actions)",
-    "Analyze (python)"
-  ],
+  "requiredStatusChecks": ["test"],
+  "codeScanningMergeProtection": {
+    "ruleset": "Require code scanning results",
+    "target": "defaultBranch",
+    "tool": "CodeQL",
+    "alertsThreshold": "errors",
+    "securityAlertsThreshold": "high_or_higher",
+    "dependabotDefaultSetupException": true
+  },
   "qaLabels": [],
   "deployLabels": [],
   "relatedRepos": [


### PR DESCRIPTION
## Summary
- remove generated per-language CodeQL jobs from ordinary required status checks
- document the dedicated CodeQL merge-protection ruleset and alert thresholds
- preserve the repository's non-CodeQL required checks

## GitHub settings applied
- require CodeQL through an active `code_scanning` ruleset on the default branch
- block CodeQL errors and high-or-higher security alerts
- retain strict branch status-check policy without the fragile `Analyze (...)` contexts

## Validation
- `jq empty .github/github.json`
- `prettier --check .github/github.json`
- `git diff --check`
